### PR TITLE
tell express handlers the request is done

### DIFF
--- a/src/handlers.coffee
+++ b/src/handlers.coffee
@@ -45,8 +45,10 @@ highbrow.installSync = (app, defaultRequest={}) ->
           options.success(JSON.parse(resultString))
         else
           options.error({status, responseText: JSON.stringify(json)})
+        res.emit('header')
       end: (msg) ->
         options.error({status: 500, responseText: msg})
+        res.emit('header')
       setHeader: ->
 
     # Call the matching route with middleware


### PR DESCRIPTION
on('header') is one of the ways that express loggers hook into the end of the chain
